### PR TITLE
Don't allow to change state on unmounted component

### DIFF
--- a/src/Columned.js
+++ b/src/Columned.js
@@ -40,17 +40,19 @@ function Columned(props: Props) {
     const [containerWidth, setContainerWidth]: [number, Function] = useState(0);
 
     useEffect(() => {
+        let canceled = false;
         if (containerRef.current) {
-            setContainerWidth(containerRef.current.offsetWidth);
+            !canceled && setContainerWidth(containerRef.current.offsetWidth);
             elementResizeDetector = elementResizeDetectorMaker({
                 strategy: "scroll"
             });
             elementResizeDetector.listenTo(containerRef.current, element =>
-                setContainerWidth(element.offsetWidth)
+                !canceled && setContainerWidth(element.offsetWidth)
             );
         }
 
         return () => {
+            canceled = true;
             if (elementResizeDetector) {
                 elementResizeDetector.uninstall(containerRef.current);
                 elementResizeDetector = null;


### PR DESCRIPTION
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
In our app when users rapidly switch between routes, `react-columned` throws an exception because it tries to run setter from `useState` on the unmounted component
![Screenshot_20200326_170442](https://user-images.githubusercontent.com/11130487/77634702-f6c92e00-6f83-11ea-95a4-e68c0160efe9.png)


## Your solution
<!--- Please describe your solution, have you encountered any issues along the way? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if relevant):